### PR TITLE
feat: add game state machine

### DIFF
--- a/evolution/src/fsm/gameMachine.ts
+++ b/evolution/src/fsm/gameMachine.ts
@@ -1,0 +1,139 @@
+import { createMachine, assign } from 'xstate'
+import { useMachine } from '@xstate/react'
+import {
+  append,
+  compactState,
+  reducer,
+  initial as initialState,
+  type GameEvent,
+  type GameState,
+} from '../engine'
+
+interface GameContext {
+  state: GameState
+  log: GameEvent[]
+  players: string[]
+  currentPlayer: number
+}
+
+type SetupEvent = { type: 'START'; seed: number; players: string[] }
+type DealEvent = { type: 'DEAL' }
+type PlayTraitEvent = {
+  type: 'PLAY_TRAIT'
+  actor: string
+  payload?: unknown
+}
+type GrowEvent = { type: 'GROW'; actor: string; payload?: unknown }
+type FeedEvent = {
+  type: 'FEED'
+  actor?: string
+  payload?: unknown
+}
+type NextEvent = { type: 'NEXT' }
+type EndFeedingEvent = { type: 'END_FEEDING' }
+type CleanupEvent = { type: 'CLEANUP' }
+type ScoreEvent = { type: 'SCORE' }
+
+type MachineEvent =
+  | SetupEvent
+  | DealEvent
+  | PlayTraitEvent
+  | GrowEvent
+  | FeedEvent
+  | NextEvent
+  | EndFeedingEvent
+  | CleanupEvent
+  | ScoreEvent
+
+const apply = (ctx: GameContext, event: GameEvent): GameContext => {
+  const next = reducer(ctx.state, event)
+  append(ctx.log, event, next, compactState)
+  return { ...ctx, state: next }
+}
+
+export const gameMachine = createMachine({
+  id: 'game',
+  types: {} as { context: GameContext; events: MachineEvent },
+  context: { state: initialState(0), log: [], players: [], currentPlayer: 0 },
+  initial: 'setup',
+  states: {
+    setup: {
+      on: {
+        START: {
+          target: 'deal',
+          actions: assign((_, e: SetupEvent) => ({
+            state: initialState(e.seed),
+            players: e.players,
+            log: [],
+            currentPlayer: 0,
+          })),
+        },
+      },
+    },
+    deal: {
+      on: {
+        DEAL: {
+          target: 'planning',
+          actions: assign((ctx) =>
+            apply(ctx, { type: 'DEAL', actor: 'system' }),
+          ),
+        },
+      },
+    },
+    planning: {
+      on: {
+        PLAY_TRAIT: {
+          actions: assign((ctx, e: PlayTraitEvent) =>
+            apply(ctx, {
+              type: 'PLAY_TRAIT',
+              actor: e.actor,
+              payload: e.payload,
+            }),
+          ),
+        },
+        GROW: {
+          actions: assign((ctx, e: GrowEvent) =>
+            apply(ctx, { type: 'GROW', actor: e.actor, payload: e.payload }),
+          ),
+        },
+        NEXT: 'feeding',
+      },
+    },
+    feeding: {
+      on: {
+        FEED: {
+          actions: assign((ctx, e: FeedEvent) => {
+            const actor = e.actor ?? ctx.players[ctx.currentPlayer]
+            const nextCtx = apply(ctx, {
+              type: 'FEED',
+              actor,
+              payload: e.payload,
+            })
+            return {
+              ...nextCtx,
+              currentPlayer: (ctx.currentPlayer + 1) % ctx.players.length,
+            }
+          }),
+        },
+        END_FEEDING: {
+          target: 'cleanup',
+        },
+      },
+    },
+    cleanup: {
+      on: {
+        CLEANUP: 'scoring',
+      },
+    },
+    scoring: {
+      on: {
+        SCORE: 'end',
+      },
+    },
+    end: {
+      type: 'final',
+    },
+  },
+})
+
+export const useGameMachine = () => useMachine(gameMachine)

--- a/evolution/src/fsm/index.ts
+++ b/evolution/src/fsm/index.ts
@@ -1,2 +1,2 @@
 // fsm module
-export {}
+export { gameMachine, useGameMachine } from './gameMachine'


### PR DESCRIPTION
## Summary
- add game state machine with phases from setup through end
- wire reducers and event log
- export useGameMachine hook for React

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca7779a348323ac58da5ac8803d38