### PR TITLE
Add basic game UI components and GameScreen

### DIFF
--- a/evolution/src/ui/components/Discard.tsx
+++ b/evolution/src/ui/components/Discard.tsx
@@ -1,0 +1,7 @@
+import type { FC } from 'react'
+
+const Discard: FC = () => {
+  return <div>Discard</div>
+}
+
+export default Discard

--- a/evolution/src/ui/components/HUD.tsx
+++ b/evolution/src/ui/components/HUD.tsx
@@ -1,0 +1,7 @@
+import type { FC } from 'react'
+
+const HUD: FC = () => {
+  return <div>HUD</div>
+}
+
+export default HUD

--- a/evolution/src/ui/components/Hand.tsx
+++ b/evolution/src/ui/components/Hand.tsx
@@ -1,0 +1,7 @@
+import type { FC } from 'react'
+
+const Hand: FC = () => {
+  return <div>Hand</div>
+}
+
+export default Hand

--- a/evolution/src/ui/components/LogView.tsx
+++ b/evolution/src/ui/components/LogView.tsx
@@ -1,0 +1,7 @@
+import type { FC } from 'react'
+
+const LogView: FC = () => {
+  return <div>LogView</div>
+}
+
+export default LogView

--- a/evolution/src/ui/components/SpeciesBoard.tsx
+++ b/evolution/src/ui/components/SpeciesBoard.tsx
@@ -1,0 +1,7 @@
+import type { FC } from 'react'
+
+const SpeciesBoard: FC = () => {
+  return <div>SpeciesBoard</div>
+}
+
+export default SpeciesBoard

--- a/evolution/src/ui/components/WateringHole.tsx
+++ b/evolution/src/ui/components/WateringHole.tsx
@@ -1,0 +1,7 @@
+import type { FC } from 'react'
+
+const WateringHole: FC = () => {
+  return <div>WateringHole</div>
+}
+
+export default WateringHole

--- a/evolution/src/ui/index.ts
+++ b/evolution/src/ui/index.ts
@@ -1,2 +1,7 @@
-// ui module
-export {}
+export { default as WateringHole } from './components/WateringHole'
+export { default as SpeciesBoard } from './components/SpeciesBoard'
+export { default as Hand } from './components/Hand'
+export { default as Discard } from './components/Discard'
+export { default as HUD } from './components/HUD'
+export { default as LogView } from './components/LogView'
+export { default as GameScreen } from './screens/GameScreen'

--- a/evolution/src/ui/screens/GameScreen.tsx
+++ b/evolution/src/ui/screens/GameScreen.tsx
@@ -1,0 +1,26 @@
+import type { FC } from 'react'
+import Discard from '../components/Discard'
+import HUD from '../components/HUD'
+import Hand from '../components/Hand'
+import LogView from '../components/LogView'
+import SpeciesBoard from '../components/SpeciesBoard'
+import WateringHole from '../components/WateringHole'
+
+const GameScreen: FC = () => {
+  return (
+    <div className="game-screen">
+      <div className="table">
+        <WateringHole />
+        <SpeciesBoard />
+        <Discard />
+        <LogView />
+      </div>
+      <div className="active-player-panel">
+        <HUD />
+        <Hand />
+      </div>
+    </div>
+  )
+}
+
+export default GameScreen


### PR DESCRIPTION
## Summary
- scaffold placeholder components for WateringHole, SpeciesBoard, Hand, Discard, HUD, and LogView
- build GameScreen that arranges common table and active player panel
- export UI components and GameScreen from ui module

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca928c8d48323a660b96d0611fc94