### PR TITLE
feat: add player switch screen and TTFT timer

### DIFF
--- a/evolution/src/App.tsx
+++ b/evolution/src/App.tsx
@@ -1,35 +1,8 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import type { FC } from 'react'
+import GameScreen from './ui/screens/GameScreen'
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+const App: FC = () => {
+  return <GameScreen />
 }
 
 export default App

--- a/evolution/src/ui/components/HUD.tsx
+++ b/evolution/src/ui/components/HUD.tsx
@@ -1,7 +1,26 @@
-import type { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 
-const HUD: FC = () => {
-  return <div>HUD</div>
+interface HUDProps {
+  onSwitchPlayer: () => void
+}
+
+const HUD: FC<HUDProps> = ({ onSwitchPlayer }) => {
+  const [elapsed, setElapsed] = useState(0)
+
+  useEffect(() => {
+    const start = Date.now()
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - start) / 1000))
+    }, 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <div>
+      <div>TTFT: {elapsed}s</div>
+      <button onClick={onSwitchPlayer}>Сменить игрока</button>
+    </div>
+  )
 }
 
 export default HUD

--- a/evolution/src/ui/components/Hand.tsx
+++ b/evolution/src/ui/components/Hand.tsx
@@ -1,7 +1,18 @@
 import type { FC } from 'react'
 
-const Hand: FC = () => {
-  return <div>Hand</div>
+interface HandProps {
+  active: boolean
+  player: number
+}
+
+const Hand: FC<HandProps> = ({ active, player }) => {
+  return (
+    <div>
+      {active
+        ? `Hand игрока ${player + 1}`
+        : `Карты игрока ${player + 1} скрыты`}
+    </div>
+  )
 }
 
 export default Hand

--- a/evolution/src/ui/screens/GameScreen.tsx
+++ b/evolution/src/ui/screens/GameScreen.tsx
@@ -1,14 +1,24 @@
-import type { FC } from 'react'
+import { FC, useState } from 'react'
 import Discard from '../components/Discard'
 import HUD from '../components/HUD'
 import Hand from '../components/Hand'
 import LogView from '../components/LogView'
 import SpeciesBoard from '../components/SpeciesBoard'
 import WateringHole from '../components/WateringHole'
+import SwitchPlayerScreen from './SwitchPlayerScreen'
 
 const GameScreen: FC = () => {
+  const [activePlayer, setActivePlayer] = useState(0)
+  const [switching, setSwitching] = useState(false)
+
+  const handleSwitch = () => setSwitching(true)
+  const handleReady = () => {
+    setActivePlayer((p) => (p + 1) % 2)
+    setSwitching(false)
+  }
+
   return (
-    <div className="game-screen">
+    <div className="game-screen" style={{ position: 'relative' }}>
       <div className="table">
         <WateringHole />
         <SpeciesBoard />
@@ -16,9 +26,10 @@ const GameScreen: FC = () => {
         <LogView />
       </div>
       <div className="active-player-panel">
-        <HUD />
-        <Hand />
+        <HUD onSwitchPlayer={handleSwitch} />
+        <Hand active={!switching} player={activePlayer} />
       </div>
+      {switching && <SwitchPlayerScreen onReady={handleReady} />}
     </div>
   )
 }

--- a/evolution/src/ui/screens/SwitchPlayerScreen.tsx
+++ b/evolution/src/ui/screens/SwitchPlayerScreen.tsx
@@ -1,0 +1,40 @@
+import type { FC } from 'react'
+
+interface SwitchPlayerScreenProps {
+  onReady: () => void
+}
+
+const SwitchPlayerScreen: FC<SwitchPlayerScreenProps> = ({ onReady }) => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0, 0, 0, 0.9)',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        color: '#fff',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: '40%',
+          background: 'rgba(0, 0, 0, 0.8)',
+        }}
+      />
+      <p>Смена игрока</p>
+      <button onClick={onReady}>Продолжить</button>
+    </div>
+  )
+}
+
+export default SwitchPlayerScreen


### PR DESCRIPTION
## Summary
- add TTFT HUD timer and player switch control
- mask hands during player change with overlay screen
- hide inactive player's cards

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acad23cbc4832399d364a4c996d105