### PR TITLE
feat: add trait modules and validations

### DIFF
--- a/evolution/src/engine/index.ts
+++ b/evolution/src/engine/index.ts
@@ -1,3 +1,4 @@
 // engine module
 export * from './log'
 export * from './state'
+export * from './traits/config'

--- a/evolution/src/engine/state.ts
+++ b/evolution/src/engine/state.ts
@@ -1,3 +1,5 @@
+import { TRAITS, type TraitId } from './traits/config'
+
 export type Phase = 'deal' | 'play' | 'grow' | 'feed'
 
 export type GameState = {
@@ -8,8 +10,8 @@ export type GameState = {
 export type DealEvent = { type: 'DEAL'; payload?: unknown }
 export type PlayTraitEvent = { type: 'PLAY_TRAIT'; payload?: unknown }
 export type GrowEvent = { type: 'GROW'; payload?: unknown }
-export type FeedEvent = { type: 'FEED'; payload?: unknown }
-export type AttackEvent = { type: 'ATTACK'; payload?: unknown }
+export type FeedEvent = { type: 'FEED'; payload?: { trait: TraitId } }
+export type AttackEvent = { type: 'ATTACK'; payload?: { trait: TraitId } }
 export type NextPhaseEvent = { type: 'NEXT_PHASE' }
 
 export type GameEvent =
@@ -55,11 +57,23 @@ export const GROW: Reducer<GrowEvent> = (state, event) => {
 
 export const FEED: Reducer<FeedEvent> = (state, event) => {
   ensurePhase(state, 'feed', event.type)
+  const trait = event.payload?.trait
+  if (!trait || !(trait in TRAITS)) {
+    throw new Error(`Unknown trait ${trait}`)
+  }
   return state
 }
 
 export const ATTACK: Reducer<AttackEvent> = (state, event) => {
   ensurePhase(state, 'feed', event.type)
+  const trait = event.payload?.trait
+  const t = trait && TRAITS[trait]
+  if (!trait || !t) {
+    throw new Error(`Unknown trait ${trait}`)
+  }
+  if (!t.attack) {
+    throw new Error(`Trait ${trait} cannot attack`)
+  }
   return state
 }
 

--- a/evolution/src/engine/traits/big.ts
+++ b/evolution/src/engine/traits/big.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const big: Trait = { id: 'big' }
+
+export default big

--- a/evolution/src/engine/traits/burrowing.ts
+++ b/evolution/src/engine/traits/burrowing.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const burrowing: Trait = { id: 'burrowing' }
+
+export default burrowing

--- a/evolution/src/engine/traits/camouflage.ts
+++ b/evolution/src/engine/traits/camouflage.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const camouflage: Trait = { id: 'camouflage' }
+
+export default camouflage

--- a/evolution/src/engine/traits/communication.ts
+++ b/evolution/src/engine/traits/communication.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const communication: Trait = { id: 'communication' }
+
+export default communication

--- a/evolution/src/engine/traits/config.ts
+++ b/evolution/src/engine/traits/config.ts
@@ -1,0 +1,44 @@
+import big from './big'
+import burrowing from './burrowing'
+import camouflage from './camouflage'
+import communication from './communication'
+import cooperation from './cooperation'
+import fatTissue from './fatTissue'
+import hibernation from './hibernation'
+import mimicry from './mimicry'
+import parasite from './parasite'
+import piracy from './piracy'
+import poisonous from './poisonous'
+import predator from './predator'
+import running from './running'
+import scavenger from './scavenger'
+import sharpVision from './sharpVision'
+import swimming from './swimming'
+import symbiosis from './symbiosis'
+import tailLoss from './tailLoss'
+import topotun from './topotun'
+
+export const TRAITS = {
+  big,
+  burrowing,
+  camouflage,
+  communication,
+  cooperation,
+  fatTissue,
+  hibernation,
+  mimicry,
+  parasite,
+  piracy,
+  poisonous,
+  predator,
+  running,
+  scavenger,
+  sharpVision,
+  swimming,
+  symbiosis,
+  tailLoss,
+  topotun,
+} as const
+
+export type TraitId = keyof typeof TRAITS
+export type Trait = (typeof TRAITS)[TraitId]

--- a/evolution/src/engine/traits/cooperation.ts
+++ b/evolution/src/engine/traits/cooperation.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const cooperation: Trait = { id: 'cooperation' }
+
+export default cooperation

--- a/evolution/src/engine/traits/fatTissue.ts
+++ b/evolution/src/engine/traits/fatTissue.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const fatTissue: Trait = { id: 'fatTissue' }
+
+export default fatTissue

--- a/evolution/src/engine/traits/hibernation.ts
+++ b/evolution/src/engine/traits/hibernation.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const hibernation: Trait = { id: 'hibernation' }
+
+export default hibernation

--- a/evolution/src/engine/traits/mimicry.ts
+++ b/evolution/src/engine/traits/mimicry.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const mimicry: Trait = { id: 'mimicry' }
+
+export default mimicry

--- a/evolution/src/engine/traits/parasite.ts
+++ b/evolution/src/engine/traits/parasite.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const parasite: Trait = { id: 'parasite', attack: true }
+
+export default parasite

--- a/evolution/src/engine/traits/piracy.ts
+++ b/evolution/src/engine/traits/piracy.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const piracy: Trait = { id: 'piracy', attack: true }
+
+export default piracy

--- a/evolution/src/engine/traits/poisonous.ts
+++ b/evolution/src/engine/traits/poisonous.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const poisonous: Trait = { id: 'poisonous' }
+
+export default poisonous

--- a/evolution/src/engine/traits/predator.ts
+++ b/evolution/src/engine/traits/predator.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const predator: Trait = { id: 'predator', attack: true }
+
+export default predator

--- a/evolution/src/engine/traits/running.ts
+++ b/evolution/src/engine/traits/running.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const running: Trait = { id: 'running' }
+
+export default running

--- a/evolution/src/engine/traits/scavenger.ts
+++ b/evolution/src/engine/traits/scavenger.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const scavenger: Trait = { id: 'scavenger' }
+
+export default scavenger

--- a/evolution/src/engine/traits/sharpVision.ts
+++ b/evolution/src/engine/traits/sharpVision.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const sharpVision: Trait = { id: 'sharpVision' }
+
+export default sharpVision

--- a/evolution/src/engine/traits/swimming.ts
+++ b/evolution/src/engine/traits/swimming.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const swimming: Trait = { id: 'swimming' }
+
+export default swimming

--- a/evolution/src/engine/traits/symbiosis.ts
+++ b/evolution/src/engine/traits/symbiosis.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const symbiosis: Trait = { id: 'symbiosis' }
+
+export default symbiosis

--- a/evolution/src/engine/traits/tailLoss.ts
+++ b/evolution/src/engine/traits/tailLoss.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const tailLoss: Trait = { id: 'tailLoss' }
+
+export default tailLoss

--- a/evolution/src/engine/traits/topotun.ts
+++ b/evolution/src/engine/traits/topotun.ts
@@ -1,0 +1,5 @@
+import type { Trait } from './types'
+
+const topotun: Trait = { id: 'topotun' }
+
+export default topotun

--- a/evolution/src/engine/traits/types.ts
+++ b/evolution/src/engine/traits/types.ts
@@ -1,0 +1,4 @@
+export type Trait = {
+  id: string
+  attack?: boolean
+}


### PR DESCRIPTION
## Summary
- add individual trait modules and central config
- export trait data from engine
- validate FEED/ATTACK events against trait invariants

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TypeScript errors in fsm/gameMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68acadb295d483238f68dd42cc087e3d